### PR TITLE
[Update]数値現象微調整しました

### DIFF
--- a/Assets/InGame/Hidaka/TimeScript.cs
+++ b/Assets/InGame/Hidaka/TimeScript.cs
@@ -52,7 +52,7 @@ public class TimeScript : MonoBehaviour
         }
         var a =  timer.Seconds.ToString();
 
-        if (timer.Seconds > 10)
+        if (timer.Seconds >= 10)
         {
             _spArray[0].sprite = sprites[int.Parse(timer.Seconds.ToString()[0].ToString())];
             _spArray[1].sprite = sprites[int.Parse(timer.Seconds.ToString()[1].ToString())];


### PR DESCRIPTION
二桁目を０にする際の判定に10が含まれていたため、
timer.Seconds > 10　から
timer.Seconds >= 10　に変更しました。